### PR TITLE
fix: :bug: Android 12+ takes color as static value instead from styles

### DIFF
--- a/lib/cmd/android_splash.dart
+++ b/lib/cmd/android_splash.dart
@@ -171,6 +171,14 @@ Future<void> createColors({
   final androidValuesFolder = isDark
       ? CmdStrings.androidDarkValuesDirectory
       : CmdStrings.androidValuesDirectory;
+
+  /// Create the directory if it doesn't exist (needed for values-night)
+  final directory = Directory(androidValuesFolder);
+  if (!await directory.exists()) {
+    await directory.create(recursive: true);
+    log('Created $androidValuesFolder directory');
+  }
+
   final colorsFilePath = '$androidValuesFolder/${AndroidStrings.colorXml}';
 
   final xmlFile = File(colorsFilePath);
@@ -304,13 +312,14 @@ Future<void> createAndroid12Styles({
         },
         nest: () {
           /// Creating a item element for color
+          /// Use color reference from colors.xml so Android uses light/dark mode colors
           if (color != null) {
             builder.element(
               AndroidStrings.itemElement,
               attributes: {
                 AndroidStrings.nameAttr: AndroidStrings.windowSplashScreenBG,
               },
-              nest: color,
+              nest: AndroidStrings.androidDrawableAttrVal,
             );
           }
 
@@ -522,6 +531,26 @@ Future<void> updateDarkStylesXml({
       color: android12AndAbove[YamlKeys.colorKey],
       imageSource: android12AndAbove[YamlKeys.imageKey],
     );
+
+    /// Create styles.xml for values-night-v31 for Android 12+ dark mode
+    /// Only create when dark color is provided
+    if (color != null) {
+      const v31Night = CmdStrings.androidDarkValuesV31Directory;
+      if (!await Directory(v31Night).exists()) {
+        Directory(v31Night).create();
+      }
+      const styleNight = '$v31Night/${AndroidStrings.stylesXml}';
+      if (await File(styleNight).exists()) {
+        File(styleNight).delete();
+      }
+      final styleFileNight = File(styleNight);
+
+      createAndroid12Styles(
+        styleFile: styleFileNight,
+        color: android12AndAbove[YamlKeys.colorKey],
+        imageSource: android12AndAbove[YamlKeys.imageKey],
+      );
+    }
   }
   final xml = File('$androidValuesFolder/${AndroidStrings.stylesXml}');
   final xmlExists = await xml.exists();

--- a/lib/cmd/cmd_strings.dart
+++ b/lib/cmd/cmd_strings.dart
@@ -37,4 +37,6 @@ class CmdStrings {
       'android/app/src/main/res/drawable';
   static const androidDarkValuesDirectory =
       'android/app/src/main/res/values-night';
+  static const androidDarkValuesV31Directory =
+      'android/app/src/main/res/values-night-v31';
 }


### PR DESCRIPTION
# Description

Adds support for different splash background colors for light mode and dark mode on Android. When a dark color is provided via the existing `color_dark_android` config option, the tool generates color resources in both `values/` and `values-night/` folders so Android automatically applies the correct theme.

**Changes:**
- Create `values-night/` directory automatically when dark color is provided
- Update Android 12+ styles to reference `@color/splashBgColor` instead of static color values for proper dark mode support
- Add `values-night-v31/` directory support for Android 12+ dark mode styles (only when `color_dark_android` is provided), ensuring `windowSplashScreenAnimatedIcon` works properly in dark mode

**Usage:**
```yaml
splash_master:
  color: '#FFFFFF'
  color_dark_android: '#000000'
```

**Generated output:**
```xml
<!-- android/app/src/main/res/values/colors.xml -->
<color name="splashBgColor">#FFFFFF</color>

<!-- android/app/src/main/res/values-night/colors.xml -->
<color name="splashBgColor">#000000</color>
```

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #20


<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/splash_master/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org

<!-- START COPILOT CODING AGENT SUFFIX -->



<details>

<summary>Original prompt</summary>

> 
> ----
> 
> *This section details on the original issue you should resolve*
> 
> <issue_title>Feature Request: Add Dark Mode Background Color Support for Android</issue_title>
> <issue_description>## Summary
> 
> Add support for different splash background colors for light mode and dark mode on Android.
> This includes generating color resources in both values/ and values-night/ folders so Android automatically applies the correct theme.
> 
> ## Expected Android Implementation
> New Config Options
> Allow users to specify:
>  - dark_background_color
> 
> Output Structure (auto-generated)
> Light mode
> 
> `android/app/src/main/res/values/colors.xml`
> ```
> <resources>
>     <color name="splash_background">#FFFFFF</color>
> </resources>
> ```
> Dark mode
> 
> `android/app/src/main/res/values-night/colors.xml`
> ```
> <resources>
>     <color name="splash_background">#000000</color>
> </resources>
> ```
> 
> Splash theme should reference this color
> ```
> <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
>     <item name="android:windowBackground">@color/splash_background</item>
> </style>
> ```
> 
> Android will automatically switch between values/ and values-night/ based on system theme.
> 
> ## Acceptance Criteria
> 
> - Add support for generating values-night/colors.xml when a dark color is provided.
> - Ensure backward compatibility if only light mode color is specified.
> - Update splash theme to reference the generated color.</issue_description>
> 
> ## Comments on the Issue (you are @copilot in this section)
> 
> <comments>
> </comments>
> 


</details>

- Fixes SimformSolutionsPvtLtd/splash_master#71