### PR TITLE
fix:🐛️ enhance Android dark mode configuration and documentation

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -60,45 +60,81 @@ This section guides you through the essential steps to implement Splash Master i
 
 ## 1. Configure Splash Master in `pubspec.yaml`
 
-Add a `splash_master` section to your `pubspec.yaml` file.
+Add a `splash_master` section to your `pubspec.yaml` file. Below is a complete configuration showing all available parameters:
 
 ```yaml
     splash_master:
-      # Use to specifies the color for the splash screen
+      # ===== Light Mode — Common Configuration =====
+      # Background color for the splash screen (light mode)
       color: '#FFFFFF'
-      # Use to specifies the splash image
+      
+      # Main splash image (used on both iOS and Android in light mode)
       image: 'assets/splash.png'
-      # Provides content mode for splash image in iOS
-      # iOS content mode options: scaleToFill, scaleAspectFit, scaleAspectFill, redraw, center, top, bottom,
+      
+      # ===== iOS Light Mode Image Behavior =====
+      # How the splash image should be displayed on iOS
+      # iOS content mode options: scaleToFill, aspectFit, aspectFill, redraw, center, top, bottom,
       # left, right, topLeft, topRight, bottomLeft, bottomRight.
       ios_content_mode: 'center'
-      # Provides gravity for splash image in Android
+      
+      # ===== Android Light Mode Image Behavior =====
+      # How the splash image should be positioned on Android
       # Android gravity options: center, clip_horizontal, clip_vertical, fill_horizontal, fill, center_vertical, 
       # bottom, fill_vertical, center_horizontal, top, end, left, right, start
       android_gravity: 'center'
-      # Use to specifies the splash image
+      
+      # ===== Background Image Configuration =====
+      # Optional background image displayed behind the main splash image
       background_image: 'assets/background_image.png'
-      # Provided content mode for splash image in background for iOS
+
+      # Optional background image displayed behind the dark mode splash image on Android
+      background_image_dark_android: 'assets/background_image_dark.png'
+      
+      # How the background image should be displayed on iOS
       ios_background_content_mode: 'scaleToFill'
-      # Provides gravity for background image in Android
-      # Android gravity options: center, clip_horizontal, clip_vertical, fill_horizontal, fill, center_vertical, 
-      # bottom, fill_vertical, center_horizontal, top, end, left, right, start
+      
+      # How the background image should be positioned on Android
+      # Options: same as android_gravity
       android_background_image_gravity: 'fill'
-      # Use to specifies image for android in dark mode
+      
+      # ===== Android Dark Mode Configuration =====
+      # Splash image to use when Android device is in dark mode
       image_dark_android: 'assets/splash_dark.png'
-      # Provides gravity for splash image for Android in dark mode
-      android_dark_gravity_key: 'center'
-      # Use to specifies the color for the splash screen for Android in dark mode
+      
+      # How the dark mode splash image should be positioned on Android
+      android_dark_gravity: 'center'
+      
+      # Background color for Android dark mode
       color_dark_android: '#000000'
-      # Section to specifies the configuration for the splash in Android 12+
+      
+      # ===== Android 12+ Specific Configuration =====
+      # Android 12 introduced a new splash screen system with specific requirements
       android_12_and_above:
-        # Provides the background color of splash screen
+        # Background color for Android 12+ splash screen
         color: '#FFFFFF'
-        # Provides custom icon to replace the default app icon
+        
+        # Custom splash icon (replaces default app icon)
+        # This should be a centered icon, ideally 288x288dp
         image: 'assets/splash_12.png'
-        # Provides branding image which is shown under main icon image. 
+        
+        # Optional branding image shown at the bottom
+        # Maximum height: 80dp, centered horizontally
         branding_image: 'assets/branding_image.png'
+
+        # Optional branding image for Android 12+ dark mode
+        branding_image_dark: 'assets/branding_image_dark.png'
 ```
+
+**Note:** The above configuration demonstrates all available parameters. You only need to include the parameters relevant to your use case.
+
+**Android dark mode details:** `background_image_dark_android` applies to the pre-Android 12 drawable-based splash. `android_background_image_gravity` is used for both light and dark background images. Inside `android_12_and_above`, `branding_image_dark` lets you provide a separate branding asset for Android 12+ dark mode.
+
+**Validation details:**
+- `branding_image`, `branding_image_dark`, and Android 12 `image`/`color` must be nested under `android_12_and_above`.
+- Putting these keys at the top level under `splash_master` is invalid and will be rejected.
+- Unknown keys at either level are rejected with a validation error.
+
+**iOS Dark Mode:** Currently, splash_master does not support iOS-specific dark mode parameters (like `image_dark_ios`, `ios_dark_content_mode`, or `color_dark_ios`). iOS uses the same splash configuration for both light and dark appearance modes. Dark mode support is available only for Android.
 
 ## 2. Generate Native Splash Screen
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,16 +1,133 @@
 # splash_master_example
 
-Demonstrates how to use the splash_master plugin.
+This example app demonstrates how to use the splash_master plugin with runnable defaults.
 
-## Getting Started
+## Features Demonstrated
 
-This project is a starting point for a Flutter application.
+This example highlights common splash_master configuration areas, including:
 
-A few resources to get you started if this is your first Flutter project:
+- ✅ **Light & Dark Mode Support** - Separate splash screens for Android dark mode
+- ✅ **Platform-Specific Configuration** - Different image behaviors for iOS and Android  
+- ✅ **Background Images** - Light and dark Android background images plus iOS background behavior
+- ✅ **Android 12+ Support** - Custom splash icons and light/dark branding images for Android 12+
+- ✅ **Gravity vs Content Mode** - Understanding the difference between Android gravity and iOS content mode
 
+> **Note on iOS Dark Mode**: The current version of splash_master does not support iOS-specific dark mode parameters (like `image_dark_ios`, `ios_dark_content_mode`, or `color_dark_ios`). iOS uses the same splash configuration for both light and dark appearance modes. Dark mode support is currently available only for Android.
+
+## Configuration Overview
+
+The `pubspec.yaml` file in this example contains a minimal runnable configuration. Expanded snippets below show additional optional parameters you can add.
+
+### Light Mode Configuration
+```yaml
+splash_master:
+  color: '#FFFFFF'                                    # Background color (light mode)
+  image: 'assets/simform_splash_img.png'             # Main splash image
+  ios_content_mode: 'aspectFit'                       # iOS image positioning
+  android_gravity: 'center'                           # Android image positioning
+```
+
+### Background Image
+```yaml
+  background_image: 'assets/background_image.png'     # Background image
+  background_image_dark_android: 'assets/background_image_dark.png' # Android dark background image
+  ios_background_content_mode: 'scaleToFill'          # iOS background positioning
+  android_background_image_gravity: 'fill'            # Android background positioning
+```
+
+### Android Dark Mode
+```yaml
+  image_dark_android: 'assets/simform_splash_img_dark.png'  # Dark mode image
+  android_dark_gravity: 'center'                             # Dark mode positioning
+  color_dark_android: '#000000'                              # Dark mode background color
+```
+
+### Android 12+ Configuration
+```yaml
+  android_12_and_above:
+    color: '#FFFFFF'                                  # Android 12+ background color
+    image: 'assets/splash_12.png'                     # Custom splash icon (288x288dp)
+    branding_image: 'assets/branding_image.png'       # Bottom branding image (max 80dp)
+    branding_image_dark: 'assets/branding_image_dark.png' # Dark mode branding image
+```
+
+## Understanding Platform Differences
+
+### iOS Content Mode
+iOS uses `content_mode` to control how images are displayed within their bounds. Common values:
+- `center` - Centers the image without scaling
+- `aspectFit` - Scales to fit while maintaining aspect ratio
+- `aspectFill` - Fills the entire area while maintaining aspect ratio
+- `scaleToFill` - Stretches to fill the entire area
+
+### Android Gravity
+Android uses `gravity` to position images within their container. Common values:
+- `center` - Centers the image
+- `fill` - Stretches the image to fill the container
+- `top`, `bottom`, `left`, `right` - Aligns to specific edges
+- `fill_horizontal`, `fill_vertical` - Fills in one direction
+
+### Android Dark Mode
+Currently, splash_master supports dark mode configuration only for Android. The dark mode splash screen is automatically used when the device is in dark mode.
+
+- `image_dark_android` swaps the main splash image in dark mode.
+- `background_image_dark_android` swaps the background image for the pre-Android 12 drawable splash.
+- `android_background_image_gravity` controls both light and dark background image placement on Android.
+- `branding_image_dark` inside `android_12_and_above` swaps the Android 12+ branding image in dark mode.
+
+Validation behavior:
+- `branding_image`, `branding_image_dark`, and Android 12 `image`/`color` are valid only inside `android_12_and_above`.
+- Unknown keys at the top level or inside `android_12_and_above` are rejected.
+
+**Note:** iOS dark mode splash support is not currently available in the plugin. iOS will use the same splash screen for both light and dark modes.
+
+### Android 12+ Splash Screen
+Android 12 introduced a new system-controlled splash screen with specific requirements:
+- **Splash Icon**: Should be a simple, centered icon (ideally 288x288dp)
+- **Branding Image**: Optional bottom image (max 80dp height)
+- **Background Color**: Single color background
+
+## Running the Example
+
+1. Ensure you have Flutter installed and configured
+2. Clone the repository
+3. Navigate to the example directory:
+   ```bash
+   cd example
+   ```
+4. Get dependencies:
+   ```bash
+   flutter pub get
+   ```
+5. Generate the native splash screens:
+   ```bash
+   dart run splash_master create
+   ```
+6. Run the app:
+   ```bash
+   flutter run
+   ```
+
+## Testing Dark Mode
+
+### Android
+To test dark mode on Android:
+1. Run the app on an Android device or emulator
+2. Enable dark mode in system settings: Settings → Display → Dark theme
+3. Restart the app to see the dark mode splash screen
+
+### iOS
+iOS does not currently support separate dark mode splash screens in splash_master. The light mode splash will be used regardless of system theme.
+
+## Additional Resources
+
+For more information about splash_master configuration and advanced features, see:
+- [Main Documentation](https://simform-flutter-packages.web.app/splashMaster)
+- [GitHub Repository](https://github.com/SimformSolutionsPvtLtd/splash_master)
+
+## Getting Started with Flutter
+
+If this is your first Flutter project, here are some resources:
 - [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
 - [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+- [Online documentation](https://docs.flutter.dev/)

--- a/lib/cmd/android_splash.dart
+++ b/lib/cmd/android_splash.dart
@@ -89,6 +89,7 @@ Future<void> generateImageForAndroid12AndAbove({
 
   final image = android12AndAbove[YamlKeys.imageKey];
   final brandingImage = android12AndAbove[YamlKeys.brandingImageKey];
+  final brandingImageDark = android12AndAbove[YamlKeys.brandingImageDarkKey];
 
   if (image != null) {
     final sourceImage = File(android12AndAbove[YamlKeys.imageKey]);
@@ -137,6 +138,31 @@ Future<void> generateImageForAndroid12AndAbove({
       drawableFolder,
       sourceImage,
     );
+  }
+
+  /// Copy dark branding image for Android 12+ dark mode
+  if (brandingImageDark != null) {
+    final sourceImage = File(brandingImageDark);
+
+    /// Checking if provided asset image source exist or not
+    if (!await sourceImage.exists()) {
+      throw SplashMasterException(
+          message: 'Dark branding image path not found: $brandingImageDark.');
+    }
+
+    final drawableFolder = '$androidResDir/$drawable';
+    final directory = Directory(drawableFolder);
+    if (!(await directory.exists())) {
+      log("$drawable folder doesn't exists. Creating it...");
+      await Directory(drawableFolder).create(recursive: true);
+    }
+
+    final imagePath =
+        '$drawableFolder/${AndroidStrings.android12BrandingImageDark}';
+    final file = File(imagePath);
+    if (await file.exists()) await file.delete();
+    await sourceImage.copy(imagePath);
+    log("Dark branding image added to $drawable");
   }
 }
 
@@ -242,15 +268,15 @@ Future<void> updateStylesXml({
           android12AndAbove[YamlKeys.brandingImageKey] != null)) {
     const v31 = CmdStrings.androidValuesV31Directory;
     if (!await Directory(v31).exists()) {
-      Directory(v31).create();
+      await Directory(v31).create();
     }
     const style = '$v31/${AndroidStrings.stylesXml}';
     if (await File(style).exists()) {
-      File(style).delete();
+      await File(style).delete();
     }
     final styleFile = File(style);
 
-    createAndroid12Styles(
+    await createAndroid12Styles(
       styleFile: styleFile,
       color: android12AndAbove[YamlKeys.colorKey],
       imageSource: android12AndAbove[YamlKeys.imageKey],
@@ -285,17 +311,17 @@ Future<void> createAndroid12Styles({
   String? color,
   String? imageSource,
   String? brandingImageSource,
+  bool isDarkBranding = false,
+  bool isDarkImage = false,
 }) async {
   final xml = await styleFile.create();
 
   final builder = XmlBuilder();
   builder.processing(AndroidStrings.xml, AndroidStrings.xmlVersion);
 
-  /// Creating a resources element
   builder.element(
     AndroidStrings.resourcesElement,
     nest: () {
-      /// Creating a style element as child of resources element
       builder.element(
         AndroidStrings.styleElement,
         attributes: {
@@ -303,7 +329,6 @@ Future<void> createAndroid12Styles({
           AndroidStrings.styleParentAttr: AndroidStrings.styleParentAttrVal,
         },
         nest: () {
-          /// Creating a item element for color
           if (color != null) {
             builder.element(
               AndroidStrings.itemElement,
@@ -313,8 +338,6 @@ Future<void> createAndroid12Styles({
               nest: color,
             );
           }
-
-          /// Creating a item element for image
           if (imageSource != null) {
             builder.element(
               AndroidStrings.itemElement,
@@ -322,7 +345,9 @@ Future<void> createAndroid12Styles({
                 AndroidStrings.nameAttr:
                     AndroidStrings.windowSplashScreenAnimatedIcon,
               },
-              nest: AndroidStrings.drawableSplashImage12,
+              nest: isDarkImage
+                  ? AndroidStrings.androidDarkSrcAttrVal
+                  : AndroidStrings.drawableSplashImage12,
             );
           }
           if (brandingImageSource != null) {
@@ -332,7 +357,9 @@ Future<void> createAndroid12Styles({
                 AndroidStrings.nameAttr:
                     AndroidStrings.windowSplashScreenBrandingImage,
               },
-              nest: AndroidStrings.drawableAndroid12BrandingImage,
+              nest: isDarkBranding
+                  ? AndroidStrings.drawableAndroid12BrandingImageDark
+                  : AndroidStrings.drawableAndroid12BrandingImage,
             );
           }
         },
@@ -435,43 +462,74 @@ Future<void> createDarkSplashImageDrawable({
   String? darkImage,
   String? color,
   String? gravity,
+  String? darkBackgroundImageSource,
+  String? backgroundImageGravity,
 }) async {
   log(darkImage ?? '');
-  if (darkImage == null) return;
-  final darkImageFile = File(darkImage);
-  if (await darkImageFile.exists()) {
-    const androidDrawableFolder = CmdStrings.androidDrawableDarkDirectory;
-    const splashImagePath =
-        '$androidDrawableFolder/${AndroidStrings.splashScreenDarkXml}';
-    final file = File(splashImagePath);
+  if (darkImage == null && darkBackgroundImageSource == null && color == null) {
+    return;
+  }
 
-    final xml = await file.create(recursive: true);
+  // Verify dark image exists if provided
+  if (darkImage != null && !await File(darkImage).exists()) {
+    throw SplashMasterException(
+        message: 'Dark splash image not found at $darkImage.');
+  }
 
-    final builder = XmlBuilder();
+  const androidDrawableFolder = CmdStrings.androidDrawableDarkDirectory;
+  const splashImagePath =
+      '$androidDrawableFolder/${AndroidStrings.splashScreenDarkXml}';
+  final file = File(splashImagePath);
 
-    builder.processing(AndroidStrings.xml, AndroidStrings.xmlVersion);
+  final xml = await file.create(recursive: true);
 
-    /// Creating a layer-list element and its attributes
-    builder.element(AndroidStrings.layerListElement, nest: () {
-      builder.attribute(
-        AndroidStrings.xmlnsAndroidAttr,
-        AndroidStrings.xmlnsAndroidAttrValue,
+  final builder = XmlBuilder();
+
+  builder.processing(AndroidStrings.xml, AndroidStrings.xmlVersion);
+
+  /// Creating a layer-list element and its attributes
+  builder.element(AndroidStrings.layerListElement, nest: () {
+    builder.attribute(
+      AndroidStrings.xmlnsAndroidAttr,
+      AndroidStrings.xmlnsAndroidAttrValue,
+    );
+
+    /// Creates item element and attributes for color
+    if (color != null) {
+      builder.element(
+        AndroidStrings.itemElement,
+        nest: () {
+          builder.attribute(
+            AndroidStrings.androidDrawableAttr,
+            AndroidStrings.androidDrawableAttrVal,
+          );
+        },
       );
+    }
 
-      /// Creates item element and attributes for color
-      if (color != null) {
-        builder.element(
-          AndroidStrings.itemElement,
-          nest: () {
-            builder.attribute(
-              AndroidStrings.androidDrawableAttr,
-              AndroidStrings.androidDrawableAttrVal,
-            );
-          },
-        );
-      }
+    /// Creates item element and attributes for dark background image
+    if (darkBackgroundImageSource != null) {
+      builder.element(AndroidStrings.itemElement, nest: () {
+        builder.element(AndroidStrings.bitmapAttrVal, nest: () {
+          builder.attribute(
+            AndroidStrings.androidGravityAttr,
+            backgroundImageGravity ??
+                AndroidStrings.defaultAndroidGravityAttrVal,
+          );
+          builder.attribute(
+            AndroidStrings.androidSrcAttr,
+            AndroidStrings.androidDarkBackgroundSrcAttrVal,
+          );
+          builder.attribute(
+            AndroidStrings.androidTileModeAttr,
+            AndroidStrings.androidTileModeAttrVal,
+          );
+        });
+      });
+    }
 
-      /// Creates item element and attributes for image
+    /// Creates item element and attributes for image (only if dark image exists)
+    if (darkImage != null) {
       builder.element(AndroidStrings.itemElement, nest: () {
         builder.element(AndroidStrings.bitmapAttrVal, nest: () {
           builder.attribute(
@@ -488,41 +546,62 @@ Future<void> createDarkSplashImageDrawable({
           );
         });
       });
-    });
+    }
+  });
 
-    final document = builder.buildDocument();
-    await xml.writeAsString(document.toXmlString(pretty: true));
-  } else {
-    throw SplashMasterException(message: "$darkImage doesn't exists.");
-  }
+  final document = builder.buildDocument();
+  await xml.writeAsString(document.toXmlString(pretty: true));
 }
 
 /// Updates the `values-night/styles.xml` file for the splash screen setup.
 Future<void> updateDarkStylesXml({
   YamlMap? android12AndAbove,
   String? color,
+  String? darkImage,
+  String? darkBrandingImage,
+  String? darkBackgroundImageSource,
 }) async {
   const androidValuesFolder = CmdStrings.androidDarkValuesDirectory;
 
   if (android12AndAbove != null &&
       (android12AndAbove[YamlKeys.colorKey] != null ||
-          android12AndAbove[YamlKeys.imageKey] != null)) {
-    const v31 = CmdStrings.androidValuesV31Directory;
+          android12AndAbove[YamlKeys.imageKey] != null ||
+          android12AndAbove[YamlKeys.brandingImageKey] != null ||
+          darkBrandingImage != null ||
+          color != null ||
+          darkImage != null)) {
+    // Use values-night-v31 for dark mode Android 12+ styles (separate from light values-v31)
+    const v31 = CmdStrings.androidDarkValuesV31Directory;
     if (!await Directory(v31).exists()) {
-      Directory(v31).create();
+      await Directory(v31).create();
     }
     const style = '$v31/${AndroidStrings.stylesXml}';
     if (await File(style).exists()) {
-      File(style).delete();
+      await File(style).delete();
     }
     final styleFile = File(style);
 
-    createAndroid12Styles(
+    await createAndroid12Styles(
       styleFile: styleFile,
-      color: android12AndAbove[YamlKeys.colorKey],
-      imageSource: android12AndAbove[YamlKeys.imageKey],
+      // Prefer explicit dark color; fall back to android_12_and_above color
+      color: color ?? android12AndAbove[YamlKeys.colorKey],
+      // Prefer explicit dark image; fall back to android_12_and_above image
+      imageSource: darkImage ?? android12AndAbove[YamlKeys.imageKey],
+      // Prefer explicit dark branding image; fall back to light branding image
+      brandingImageSource:
+          darkBrandingImage ?? android12AndAbove[YamlKeys.brandingImageKey],
+      isDarkBranding: darkBrandingImage != null,
+      isDarkImage: darkImage != null,
     );
   }
+  // Pre-12 dark styles are optional and independent from Android 12+ (values-night-v31).
+  if (darkImage == null && darkBackgroundImageSource == null && color == null) {
+    log(
+      'Skipping values-night/styles.xml update as no pre-Android 12 dark image, dark background image, or dark color was provided.',
+    );
+    return;
+  }
+
   final xml = File('$androidValuesFolder/${AndroidStrings.stylesXml}');
   final xmlExists = await xml.exists();
   if (!xmlExists) {

--- a/lib/cmd/cmd_strings.dart
+++ b/lib/cmd/cmd_strings.dart
@@ -37,4 +37,6 @@ class CmdStrings {
       'android/app/src/main/res/drawable';
   static const androidDarkValuesDirectory =
       'android/app/src/main/res/values-night';
+  static const androidDarkValuesV31Directory =
+      'android/app/src/main/res/values-night-v31';
 }

--- a/lib/cmd/command_line.dart
+++ b/lib/cmd/command_line.dart
@@ -38,7 +38,6 @@ import 'package:yaml/yaml.dart';
 import 'logging.dart';
 
 part 'android_splash.dart';
-
 part 'ios_splash.dart';
 
 void commandEntry(List<String> arguments) {
@@ -82,12 +81,47 @@ void commandEntry(List<String> arguments) {
 
 /// Setting up the splash screen using the details provided in `pubspec.yaml` file under `splash_master`.
 void setupSplashScreen(YamlMap splashData) {
+  final splashKeys = splashData.keys.map((e) => e.toString()).toSet();
+  final unsupportedTopLevelKeys = splashKeys
+      .where((key) => !YamlKeys.supportedYamlKeys.contains(key))
+      .toList();
+
   /// Checking keys in the `splash_master` section in `pubspec.yaml` file is proper or not.
-  if (YamlKeys.supportedYamlKeys.any(
-    (element) => splashData.keys.any(
-      (e) => e == element,
-    ),
-  )) {
+  if (unsupportedTopLevelKeys.isNotEmpty) {
+    log(
+      'Unsupported key(s) in splash_master: '
+      '${unsupportedTopLevelKeys.join(', ')}. '
+      'Supported keys are: ${YamlKeys.supportedYamlKeys.join(', ')}',
+    );
+    return;
+  }
+
+  final android12AndAbove = splashData[YamlKeys.android12AndAboveKey];
+  if (android12AndAbove != null && android12AndAbove is! YamlMap) {
+    log('Please check the android_12_and_above configuration. All parameters must be nested under the android_12_and_above key.');
+    return;
+  }
+
+  if (android12AndAbove != null) {
+    final android12Keys =
+        android12AndAbove.keys.map((e) => e.toString()).toSet();
+    final unsupportedAndroid12Keys = android12Keys
+        .where(
+          (key) => !YamlKeys.supportedAndroid12AndAboveYamlKeys.contains(key),
+        )
+        .toList();
+    if (unsupportedAndroid12Keys.isNotEmpty) {
+      log(
+        'Unsupported key(s) in android_12_and_above: '
+        '${unsupportedAndroid12Keys.join(', ')}. '
+        'Supported keys are: '
+        '${YamlKeys.supportedAndroid12AndAboveYamlKeys.join(', ')}',
+      );
+      return;
+    }
+  }
+
+  {
     IosContentMode? iosContentMode;
     if (splashData[YamlKeys.iosContentModeKey] != null) {
       iosContentMode =
@@ -123,7 +157,7 @@ void setupSplashScreen(YamlMap splashData) {
             element ==
             SupportedImageExtensions.fromString(imgExtension.toLowerCase()),
       )) {
-        log('Image should be png or jpg');
+        log('Image should be png, jpg, or jpeg.');
         return;
       }
     } else if (splashData[YamlKeys.androidBackgroundGravity] != null &&
@@ -147,8 +181,10 @@ void setupSplashScreen(YamlMap splashData) {
       backgroundImageSource: splashData[YamlKeys.backgroundImage],
       backgroundImageGravity: splashData[YamlKeys.androidBackgroundGravity],
       darkColor: splashData[YamlKeys.colorDarkAndroid],
-      darkGravity: splashData[YamlKeys.androidGravityKey],
+      darkGravity: splashData[YamlKeys.androidDarkGravityKey],
       darkImage: splashData[YamlKeys.imageDarkAndroid],
+      darkBackgroundImageSource:
+          splashData[YamlKeys.backgroundImageDarkAndroid],
     );
   }
 }
@@ -165,28 +201,30 @@ Future<void> applyAndroidSplashImage({
   String? darkImage,
   String? darkColor,
   String? darkGravity,
+  String? darkBackgroundImageSource,
 }) async {
   await generateAndroidImages(
     imageSource: imageSource,
     darkImageSource: darkImage,
   );
   if (backgroundImageSource != null) {
-    generateAndroidImages(
+    await generateAndroidImages(
       imageSource: backgroundImageSource,
       backgroundImageName: AndroidStrings.splashBackgroundImagePng,
+    );
+  }
+  if (darkBackgroundImageSource != null) {
+    await generateAndroidImages(
+      imageSource: darkBackgroundImageSource,
+      backgroundImageName: AndroidStrings.splashBackgroundImageDarkPng,
     );
   }
   await generateImageForAndroid12AndAbove(
     android12AndAbove: android12AndAbove,
   );
-  await createColors(
-    color: color,
-  );
+  await createColors(color: color);
   if (darkColor != null) {
-    await createColors(
-      color: darkColor,
-      isDark: true,
-    );
+    await createColors(color: darkColor, isDark: true);
   }
   await createSplashImageDrawable(
     imageSource: imageSource,
@@ -199,15 +237,24 @@ Future<void> applyAndroidSplashImage({
     darkImage: darkImage,
     color: darkColor,
     gravity: darkGravity,
+    darkBackgroundImageSource: darkBackgroundImageSource,
+    backgroundImageGravity: backgroundImageGravity,
   );
   await updateStylesXml(
     android12AndAbove: android12AndAbove,
     color: color,
   );
-  if (darkImage != null) {
+  final darkBrandingImage = android12AndAbove?[YamlKeys.brandingImageDarkKey];
+  if (darkImage != null ||
+      darkBrandingImage != null ||
+      darkBackgroundImageSource != null ||
+      darkColor != null) {
     await updateDarkStylesXml(
       android12AndAbove: android12AndAbove,
       color: darkColor,
+      darkImage: darkImage,
+      darkBrandingImage: darkBrandingImage,
+      darkBackgroundImageSource: darkBackgroundImageSource,
     );
   }
 }
@@ -226,6 +273,7 @@ Future<void> applySplash({
   String? darkImage,
   String? darkColor,
   String? darkGravity,
+  String? darkBackgroundImageSource,
 }) async {
   await generateIosImages(
     imageSource: imageSource,
@@ -244,5 +292,6 @@ Future<void> applySplash({
     darkImage: darkImage,
     darkColor: darkColor,
     darkGravity: darkGravity,
+    darkBackgroundImageSource: darkBackgroundImageSource,
   );
 }

--- a/lib/values/android_strings.dart
+++ b/lib/values/android_strings.dart
@@ -128,6 +128,21 @@ class AndroidStrings {
   /// `background_image.png`
   static const splashBackgroundImagePng = 'background_image.png';
 
+  /// `background_image_dark.png`
+  static const splashBackgroundImageDarkPng = 'background_image_dark.png';
+
+  /// `@drawable/background_image_dark`
+  static const androidDarkBackgroundSrcAttrVal =
+      '@drawable/background_image_dark';
+
+  /// `android_12_branding_image_dark.png`
+  static const android12BrandingImageDark =
+      'android_12_branding_image_dark.png';
+
+  /// `@drawable/android_12_branding_image_dark`
+  static const drawableAndroid12BrandingImageDark =
+      '@drawable/android_12_branding_image_dark';
+
   /// `@drawable/splash_screen_dark`
   static const androidDarkDrawable = '@drawable/splash_screen_dark';
 

--- a/lib/values/yaml_keys.dart
+++ b/lib/values/yaml_keys.dart
@@ -57,19 +57,33 @@ class YamlKeys {
   /// Specifies color for android dark mode
   static const colorDarkAndroid = 'color_dark_android';
 
-  /// List of supported keys
+  /// Specifies dark background image for android dark mode (pre-Android 12)
+  static const backgroundImageDarkAndroid = 'background_image_dark_android';
+
+  /// Specifies dark branding image for Android 12+ dark mode
+  static const brandingImageDarkKey = 'branding_image_dark';
+
+  /// List of supported top-level keys under `splash_master`.
   static List<String> supportedYamlKeys = [
     imageKey,
     colorKey,
     androidGravityKey,
     iosContentModeKey,
     android12AndAboveKey,
-    brandingImageKey,
     backgroundImage,
     iosBackgroundContentMode,
     androidBackgroundGravity,
     imageDarkAndroid,
     androidDarkGravityKey,
     colorDarkAndroid,
+    backgroundImageDarkAndroid,
+  ];
+
+  /// List of supported nested keys under `android_12_and_above`.
+  static List<String> supportedAndroid12AndAboveYamlKeys = [
+    imageKey,
+    colorKey,
+    brandingImageKey,
+    brandingImageDarkKey,
   ];
 }


### PR DESCRIPTION
# Description
This PR improves Android dark-mode splash handling, especially for Android 12+ resource generation and style separation.

### Existing behavior
Dark-mode updates for Android 12+ and pre-Android 12 were not clearly separated, which could lead to light/dark resource overlap and unnecessary updates to `values-night/styles.xml`. In addition, dark asset handling had limited fallback behavior and validation for some inputs.

### What this PR changes
- Adds/uses dedicated Android 12+ dark style output in `values-night-v31/styles.xml` (separate from light `values-v31`).
- Updates dark Android 12 style generation to:
  - Prefer explicit dark inputs (`darkImage`, `darkBrandingImage`, dark color).
  - Fall back to `android_12_and_above` values when explicit dark values are not provided.
- Improves dark branding support for Android 12+ by wiring dark branding resources and style references.
- Tightens pre-Android 12 dark behavior:
  - Skips `values-night/styles.xml` updates when no dark pre-12 inputs are provided.
  - Avoids unnecessary style mutations when dark drawable inputs are absent.
- Adds/keeps validation for dark image existence before generating dark drawable XML resources.

### Motivation
These changes make dark-mode splash generation more predictable, prevent accidental style/resource overrides, and align Android 12+ dark configuration with expected platform-specific resource directories.

### Scope
- Primary updates are in `lib/cmd/android_splash.dart`.
- No public API changes introduced.


## Checklist
- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
None