### PR TITLE
fix:🐛️ enhance Android dark mode configuration

### DIFF
--- a/lib/cmd/android_splash.dart
+++ b/lib/cmd/android_splash.dart
@@ -89,6 +89,7 @@ Future<void> generateImageForAndroid12AndAbove({
 
   final image = android12AndAbove[YamlKeys.imageKey];
   final brandingImage = android12AndAbove[YamlKeys.brandingImageKey];
+  final brandingImageDark = android12AndAbove[YamlKeys.brandingImageDarkKey];
 
   if (image != null) {
     final sourceImage = File(android12AndAbove[YamlKeys.imageKey]);
@@ -137,6 +138,31 @@ Future<void> generateImageForAndroid12AndAbove({
       drawableFolder,
       sourceImage,
     );
+  }
+
+  /// Copy dark branding image for Android 12+ dark mode
+  if (brandingImageDark != null) {
+    final sourceImage = File(brandingImageDark);
+
+    /// Checking if provided asset image source exist or not
+    if (!await sourceImage.exists()) {
+      throw SplashMasterException(
+          message: 'Dark branding image path not found: $brandingImageDark.');
+    }
+
+    final drawableFolder = '$androidResDir/$drawable';
+    final directory = Directory(drawableFolder);
+    if (!(await directory.exists())) {
+      log("$drawable folder doesn't exists. Creating it...");
+      await Directory(drawableFolder).create(recursive: true);
+    }
+
+    final imagePath =
+        '$drawableFolder/${AndroidStrings.android12BrandingImageDark}';
+    final file = File(imagePath);
+    if (await file.exists()) await file.delete();
+    await sourceImage.copy(imagePath);
+    log("Dark branding image added to $drawable");
   }
 }
 
@@ -242,15 +268,15 @@ Future<void> updateStylesXml({
           android12AndAbove[YamlKeys.brandingImageKey] != null)) {
     const v31 = CmdStrings.androidValuesV31Directory;
     if (!await Directory(v31).exists()) {
-      Directory(v31).create();
+      await Directory(v31).create();
     }
     const style = '$v31/${AndroidStrings.stylesXml}';
     if (await File(style).exists()) {
-      File(style).delete();
+      await File(style).delete();
     }
     final styleFile = File(style);
 
-    createAndroid12Styles(
+    await createAndroid12Styles(
       styleFile: styleFile,
       color: android12AndAbove[YamlKeys.colorKey],
       imageSource: android12AndAbove[YamlKeys.imageKey],
@@ -285,17 +311,17 @@ Future<void> createAndroid12Styles({
   String? color,
   String? imageSource,
   String? brandingImageSource,
+  bool isDarkBranding = false,
+  bool isDarkImage = false,
 }) async {
   final xml = await styleFile.create();
 
   final builder = XmlBuilder();
   builder.processing(AndroidStrings.xml, AndroidStrings.xmlVersion);
 
-  /// Creating a resources element
   builder.element(
     AndroidStrings.resourcesElement,
     nest: () {
-      /// Creating a style element as child of resources element
       builder.element(
         AndroidStrings.styleElement,
         attributes: {
@@ -303,7 +329,6 @@ Future<void> createAndroid12Styles({
           AndroidStrings.styleParentAttr: AndroidStrings.styleParentAttrVal,
         },
         nest: () {
-          /// Creating a item element for color
           if (color != null) {
             builder.element(
               AndroidStrings.itemElement,
@@ -313,8 +338,6 @@ Future<void> createAndroid12Styles({
               nest: color,
             );
           }
-
-          /// Creating a item element for image
           if (imageSource != null) {
             builder.element(
               AndroidStrings.itemElement,
@@ -322,7 +345,9 @@ Future<void> createAndroid12Styles({
                 AndroidStrings.nameAttr:
                     AndroidStrings.windowSplashScreenAnimatedIcon,
               },
-              nest: AndroidStrings.drawableSplashImage12,
+              nest: isDarkImage
+                  ? AndroidStrings.androidDarkSrcAttrVal
+                  : AndroidStrings.drawableSplashImage12,
             );
           }
           if (brandingImageSource != null) {
@@ -332,7 +357,9 @@ Future<void> createAndroid12Styles({
                 AndroidStrings.nameAttr:
                     AndroidStrings.windowSplashScreenBrandingImage,
               },
-              nest: AndroidStrings.drawableAndroid12BrandingImage,
+              nest: isDarkBranding
+                  ? AndroidStrings.drawableAndroid12BrandingImageDark
+                  : AndroidStrings.drawableAndroid12BrandingImage,
             );
           }
         },
@@ -435,43 +462,74 @@ Future<void> createDarkSplashImageDrawable({
   String? darkImage,
   String? color,
   String? gravity,
+  String? darkBackgroundImageSource,
+  String? backgroundImageGravity,
 }) async {
   log(darkImage ?? '');
-  if (darkImage == null) return;
-  final darkImageFile = File(darkImage);
-  if (await darkImageFile.exists()) {
-    const androidDrawableFolder = CmdStrings.androidDrawableDarkDirectory;
-    const splashImagePath =
-        '$androidDrawableFolder/${AndroidStrings.splashScreenDarkXml}';
-    final file = File(splashImagePath);
+  if (darkImage == null && darkBackgroundImageSource == null && color == null) {
+    return;
+  }
 
-    final xml = await file.create(recursive: true);
+  // Verify dark image exists if provided
+  if (darkImage != null && !await File(darkImage).exists()) {
+    throw SplashMasterException(
+        message: 'Dark splash image not found at $darkImage.');
+  }
 
-    final builder = XmlBuilder();
+  const androidDrawableFolder = CmdStrings.androidDrawableDarkDirectory;
+  const splashImagePath =
+      '$androidDrawableFolder/${AndroidStrings.splashScreenDarkXml}';
+  final file = File(splashImagePath);
 
-    builder.processing(AndroidStrings.xml, AndroidStrings.xmlVersion);
+  final xml = await file.create(recursive: true);
 
-    /// Creating a layer-list element and its attributes
-    builder.element(AndroidStrings.layerListElement, nest: () {
-      builder.attribute(
-        AndroidStrings.xmlnsAndroidAttr,
-        AndroidStrings.xmlnsAndroidAttrValue,
+  final builder = XmlBuilder();
+
+  builder.processing(AndroidStrings.xml, AndroidStrings.xmlVersion);
+
+  /// Creating a layer-list element and its attributes
+  builder.element(AndroidStrings.layerListElement, nest: () {
+    builder.attribute(
+      AndroidStrings.xmlnsAndroidAttr,
+      AndroidStrings.xmlnsAndroidAttrValue,
+    );
+
+    /// Creates item element and attributes for color
+    if (color != null) {
+      builder.element(
+        AndroidStrings.itemElement,
+        nest: () {
+          builder.attribute(
+            AndroidStrings.androidDrawableAttr,
+            AndroidStrings.androidDrawableAttrVal,
+          );
+        },
       );
+    }
 
-      /// Creates item element and attributes for color
-      if (color != null) {
-        builder.element(
-          AndroidStrings.itemElement,
-          nest: () {
-            builder.attribute(
-              AndroidStrings.androidDrawableAttr,
-              AndroidStrings.androidDrawableAttrVal,
-            );
-          },
-        );
-      }
+    /// Creates item element and attributes for dark background image
+    if (darkBackgroundImageSource != null) {
+      builder.element(AndroidStrings.itemElement, nest: () {
+        builder.element(AndroidStrings.bitmapAttrVal, nest: () {
+          builder.attribute(
+            AndroidStrings.androidGravityAttr,
+            backgroundImageGravity ??
+                AndroidStrings.defaultAndroidGravityAttrVal,
+          );
+          builder.attribute(
+            AndroidStrings.androidSrcAttr,
+            AndroidStrings.androidDarkBackgroundSrcAttrVal,
+          );
+          builder.attribute(
+            AndroidStrings.androidTileModeAttr,
+            AndroidStrings.androidTileModeAttrVal,
+          );
+        });
+      });
+    }
 
-      /// Creates item element and attributes for image
+    /// Creates item element and attributes for image (only if dark image exists)
+    if (darkImage != null) {
       builder.element(AndroidStrings.itemElement, nest: () {
         builder.element(AndroidStrings.bitmapAttrVal, nest: () {
           builder.attribute(
@@ -488,41 +546,62 @@ Future<void> createDarkSplashImageDrawable({
           );
         });
       });
-    });
+    }
+  });
 
-    final document = builder.buildDocument();
-    await xml.writeAsString(document.toXmlString(pretty: true));
-  } else {
-    throw SplashMasterException(message: "$darkImage doesn't exists.");
-  }
+  final document = builder.buildDocument();
+  await xml.writeAsString(document.toXmlString(pretty: true));
 }
 
 /// Updates the `values-night/styles.xml` file for the splash screen setup.
 Future<void> updateDarkStylesXml({
   YamlMap? android12AndAbove,
   String? color,
+  String? darkImage,
+  String? darkBrandingImage,
+  String? darkBackgroundImageSource,
 }) async {
   const androidValuesFolder = CmdStrings.androidDarkValuesDirectory;
 
   if (android12AndAbove != null &&
       (android12AndAbove[YamlKeys.colorKey] != null ||
-          android12AndAbove[YamlKeys.imageKey] != null)) {
-    const v31 = CmdStrings.androidValuesV31Directory;
+          android12AndAbove[YamlKeys.imageKey] != null ||
+          android12AndAbove[YamlKeys.brandingImageKey] != null ||
+          darkBrandingImage != null ||
+          color != null ||
+          darkImage != null)) {
+    // Use values-night-v31 for dark mode Android 12+ styles (separate from light values-v31)
+    const v31 = CmdStrings.androidDarkValuesV31Directory;
     if (!await Directory(v31).exists()) {
-      Directory(v31).create();
+      await Directory(v31).create();
     }
     const style = '$v31/${AndroidStrings.stylesXml}';
     if (await File(style).exists()) {
-      File(style).delete();
+      await File(style).delete();
     }
     final styleFile = File(style);
 
-    createAndroid12Styles(
+    await createAndroid12Styles(
       styleFile: styleFile,
-      color: android12AndAbove[YamlKeys.colorKey],
-      imageSource: android12AndAbove[YamlKeys.imageKey],
+      // Prefer explicit dark color; fall back to android_12_and_above color
+      color: color ?? android12AndAbove[YamlKeys.colorKey],
+      // Prefer explicit dark image; fall back to android_12_and_above image
+      imageSource: darkImage ?? android12AndAbove[YamlKeys.imageKey],
+      // Prefer explicit dark branding image; fall back to light branding image
+      brandingImageSource:
+          darkBrandingImage ?? android12AndAbove[YamlKeys.brandingImageKey],
+      isDarkBranding: darkBrandingImage != null,
+      isDarkImage: darkImage != null,
     );
   }
+  // Pre-12 dark styles are optional and independent from Android 12+ (values-night-v31).
+  if (darkImage == null && darkBackgroundImageSource == null && color == null) {
+    log(
+      'Skipping values-night/styles.xml update as no pre-Android 12 dark image, dark background image, or dark color was provided.',
+    );
+    return;
+  }
+
   final xml = File('$androidValuesFolder/${AndroidStrings.stylesXml}');
   final xmlExists = await xml.exists();
   if (!xmlExists) {

--- a/lib/cmd/cmd_strings.dart
+++ b/lib/cmd/cmd_strings.dart
@@ -37,4 +37,6 @@ class CmdStrings {
       'android/app/src/main/res/drawable';
   static const androidDarkValuesDirectory =
       'android/app/src/main/res/values-night';
+  static const androidDarkValuesV31Directory =
+      'android/app/src/main/res/values-night-v31';
 }

--- a/lib/cmd/command_line.dart
+++ b/lib/cmd/command_line.dart
@@ -38,7 +38,6 @@ import 'package:yaml/yaml.dart';
 import 'logging.dart';
 
 part 'android_splash.dart';
-
 part 'ios_splash.dart';
 
 void commandEntry(List<String> arguments) {
@@ -82,12 +81,47 @@ void commandEntry(List<String> arguments) {
 
 /// Setting up the splash screen using the details provided in `pubspec.yaml` file under `splash_master`.
 void setupSplashScreen(YamlMap splashData) {
+  final splashKeys = splashData.keys.map((e) => e.toString()).toSet();
+  final unsupportedTopLevelKeys = splashKeys
+      .where((key) => !YamlKeys.supportedYamlKeys.contains(key))
+      .toList();
+
   /// Checking keys in the `splash_master` section in `pubspec.yaml` file is proper or not.
-  if (YamlKeys.supportedYamlKeys.any(
-    (element) => splashData.keys.any(
-      (e) => e == element,
-    ),
-  )) {
+  if (unsupportedTopLevelKeys.isNotEmpty) {
+    log(
+      'Unsupported key(s) in splash_master: '
+      '${unsupportedTopLevelKeys.join(', ')}. '
+      'Supported keys are: ${YamlKeys.supportedYamlKeys.join(', ')}',
+    );
+    return;
+  }
+
+  final android12AndAbove = splashData[YamlKeys.android12AndAboveKey];
+  if (android12AndAbove != null && android12AndAbove is! YamlMap) {
+    log('Please check the android_12_and_above configuration. All parameters must be nested under the android_12_and_above key.');
+    return;
+  }
+
+  if (android12AndAbove != null) {
+    final android12Keys =
+        android12AndAbove.keys.map((e) => e.toString()).toSet();
+    final unsupportedAndroid12Keys = android12Keys
+        .where(
+          (key) => !YamlKeys.supportedAndroid12AndAboveYamlKeys.contains(key),
+        )
+        .toList();
+    if (unsupportedAndroid12Keys.isNotEmpty) {
+      log(
+        'Unsupported key(s) in android_12_and_above: '
+        '${unsupportedAndroid12Keys.join(', ')}. '
+        'Supported keys are: '
+        '${YamlKeys.supportedAndroid12AndAboveYamlKeys.join(', ')}',
+      );
+      return;
+    }
+  }
+
+  {
     IosContentMode? iosContentMode;
     if (splashData[YamlKeys.iosContentModeKey] != null) {
       iosContentMode =
@@ -123,7 +157,7 @@ void setupSplashScreen(YamlMap splashData) {
             element ==
             SupportedImageExtensions.fromString(imgExtension.toLowerCase()),
       )) {
-        log('Image should be png or jpg');
+        log('Image should be png, jpg, or jpeg.');
         return;
       }
     } else if (splashData[YamlKeys.androidBackgroundGravity] != null &&
@@ -147,8 +181,10 @@ void setupSplashScreen(YamlMap splashData) {
       backgroundImageSource: splashData[YamlKeys.backgroundImage],
       backgroundImageGravity: splashData[YamlKeys.androidBackgroundGravity],
       darkColor: splashData[YamlKeys.colorDarkAndroid],
-      darkGravity: splashData[YamlKeys.androidGravityKey],
+      darkGravity: splashData[YamlKeys.androidDarkGravityKey],
       darkImage: splashData[YamlKeys.imageDarkAndroid],
+      darkBackgroundImageSource:
+          splashData[YamlKeys.backgroundImageDarkAndroid],
     );
   }
 }
@@ -165,28 +201,30 @@ Future<void> applyAndroidSplashImage({
   String? darkImage,
   String? darkColor,
   String? darkGravity,
+  String? darkBackgroundImageSource,
 }) async {
   await generateAndroidImages(
     imageSource: imageSource,
     darkImageSource: darkImage,
   );
   if (backgroundImageSource != null) {
-    generateAndroidImages(
+    await generateAndroidImages(
       imageSource: backgroundImageSource,
       backgroundImageName: AndroidStrings.splashBackgroundImagePng,
+    );
+  }
+  if (darkBackgroundImageSource != null) {
+    await generateAndroidImages(
+      imageSource: darkBackgroundImageSource,
+      backgroundImageName: AndroidStrings.splashBackgroundImageDarkPng,
     );
   }
   await generateImageForAndroid12AndAbove(
     android12AndAbove: android12AndAbove,
   );
-  await createColors(
-    color: color,
-  );
+  await createColors(color: color);
   if (darkColor != null) {
-    await createColors(
-      color: darkColor,
-      isDark: true,
-    );
+    await createColors(color: darkColor, isDark: true);
   }
   await createSplashImageDrawable(
     imageSource: imageSource,
@@ -199,15 +237,24 @@ Future<void> applyAndroidSplashImage({
     darkImage: darkImage,
     color: darkColor,
     gravity: darkGravity,
+    darkBackgroundImageSource: darkBackgroundImageSource,
+    backgroundImageGravity: backgroundImageGravity,
   );
   await updateStylesXml(
     android12AndAbove: android12AndAbove,
     color: color,
   );
-  if (darkImage != null) {
+  final darkBrandingImage = android12AndAbove?[YamlKeys.brandingImageDarkKey];
+  if (darkImage != null ||
+      darkBrandingImage != null ||
+      darkBackgroundImageSource != null ||
+      darkColor != null) {
     await updateDarkStylesXml(
       android12AndAbove: android12AndAbove,
       color: darkColor,
+      darkImage: darkImage,
+      darkBrandingImage: darkBrandingImage,
+      darkBackgroundImageSource: darkBackgroundImageSource,
     );
   }
 }
@@ -226,6 +273,7 @@ Future<void> applySplash({
   String? darkImage,
   String? darkColor,
   String? darkGravity,
+  String? darkBackgroundImageSource,
 }) async {
   await generateIosImages(
     imageSource: imageSource,
@@ -244,5 +292,6 @@ Future<void> applySplash({
     darkImage: darkImage,
     darkColor: darkColor,
     darkGravity: darkGravity,
+    darkBackgroundImageSource: darkBackgroundImageSource,
   );
 }

--- a/lib/values/android_strings.dart
+++ b/lib/values/android_strings.dart
@@ -128,6 +128,21 @@ class AndroidStrings {
   /// `background_image.png`
   static const splashBackgroundImagePng = 'background_image.png';
 
+  /// `background_image_dark.png`
+  static const splashBackgroundImageDarkPng = 'background_image_dark.png';
+
+  /// `@drawable/background_image_dark`
+  static const androidDarkBackgroundSrcAttrVal =
+      '@drawable/background_image_dark';
+
+  /// `android_12_branding_image_dark.png`
+  static const android12BrandingImageDark =
+      'android_12_branding_image_dark.png';
+
+  /// `@drawable/android_12_branding_image_dark`
+  static const drawableAndroid12BrandingImageDark =
+      '@drawable/android_12_branding_image_dark';
+
   /// `@drawable/splash_screen_dark`
   static const androidDarkDrawable = '@drawable/splash_screen_dark';
 

--- a/lib/values/yaml_keys.dart
+++ b/lib/values/yaml_keys.dart
@@ -57,19 +57,33 @@ class YamlKeys {
   /// Specifies color for android dark mode
   static const colorDarkAndroid = 'color_dark_android';
 
-  /// List of supported keys
+  /// Specifies dark background image for android dark mode (pre-Android 12)
+  static const backgroundImageDarkAndroid = 'background_image_dark_android';
+
+  /// Specifies dark branding image for Android 12+ dark mode
+  static const brandingImageDarkKey = 'branding_image_dark';
+
+  /// List of supported top-level keys under `splash_master`.
   static List<String> supportedYamlKeys = [
     imageKey,
     colorKey,
     androidGravityKey,
     iosContentModeKey,
     android12AndAboveKey,
-    brandingImageKey,
     backgroundImage,
     iosBackgroundContentMode,
     androidBackgroundGravity,
     imageDarkAndroid,
     androidDarkGravityKey,
     colorDarkAndroid,
+    backgroundImageDarkAndroid,
+  ];
+
+  /// List of supported nested keys under `android_12_and_above`.
+  static List<String> supportedAndroid12AndAboveYamlKeys = [
+    imageKey,
+    colorKey,
+    brandingImageKey,
+    brandingImageDarkKey,
   ];
 }


### PR DESCRIPTION
# Description
This PR improves Android dark-mode splash handling, especially for Android 12+ resource generation and style separation.

### Existing behavior
Dark-mode updates for Android 12+ and pre-Android 12 were not clearly separated, which could lead to light/dark resource overlap and unnecessary updates to `values-night/styles.xml`. In addition, dark asset handling had limited fallback behavior and validation for some inputs.

### What this PR changes
- Adds/uses dedicated Android 12+ dark style output in `values-night-v31/styles.xml` (separate from light `values-v31`).
- Updates dark Android 12 style generation to:
  - Prefer explicit dark inputs (`darkImage`, `darkBrandingImage`, dark color).
  - Fall back to `android_12_and_above` values when explicit dark values are not provided.
- Improves dark branding support for Android 12+ by wiring dark branding resources and style references.
- Tightens pre-Android 12 dark behavior:
  - Skips `values-night/styles.xml` updates when no dark pre-12 inputs are provided.
  - Avoids unnecessary style mutations when dark drawable inputs are absent.
- Adds/keeps validation for dark image existence before generating dark drawable XML resources.

### Motivation
These changes make dark-mode splash generation more predictable, prevent accidental style/resource overrides, and align Android 12+ dark configuration with expected platform-specific resource directories.

### Scope
- Primary updates are in `lib/cmd/android_splash.dart`.
- No public API changes introduced.


## Checklist
- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
None