### PR TITLE
♻️ Update documentation for SplashMaster API changes and lifecycle methods

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -415,17 +415,27 @@ This version standardizes dark-mode keys, enforces strict config validation, int
 
 ### Flutter Widget API Changes
 
-`SplashMaster.rive(...)`, `SplashMaster.video(...)`, and `SplashMaster.lottie(...)` have been removed from the `splash_master` package. Add the relevant sub-package and rename the widget:
+The `SplashMaster` factory class has been removed. Animation widgets have been moved to dedicated sub-packages:
 
-| Before (0.0.3)              | After (1.0.0)            | New package              |
-|-----------------------------|--------------------------|--------------------------|
-| `SplashMaster.rive(...)`    | `SplashMasterRive(...)`        | `splash_master_rive`     |
-| `SplashMaster.video(...)`   | `SplashMasterVideo(...)`       | `splash_master_video`    |
-| `SplashMaster.lottie(...)`  | `SplashMasterLottie(...)`      | `splash_master_lottie`   |
-| `SplashMaster.initialize()` | `<Widget>.initialize()`  | same sub-package widget  |
-| `SplashMaster.resume()`     | `<Widget>.resume()`      | same sub-package widget  |
+| Before (0.0.3)              | After (1.0.0)            | Notes                                |
+|-----------------------------|--------------------------|--------------------------------------|
+| `SplashMaster.rive(...)`    | `SplashMasterRive(...)`  | Requires `splash_master_rive` package |
+| `SplashMaster.video(...)`   | `SplashMasterVideo(...)` | Requires `splash_master_video` package |
+| `SplashMaster.lottie(...)`  | `SplashMasterLottie(...)` | Requires `splash_master_lottie` package |
+| `SplashMaster.initialize()` | `<Widget>.initialize()`  | **Only needed for animation widgets** |
+| `SplashMaster.resume()`     | `<Widget>.resume()`      | **Only needed for animation widgets** |
 
-Apps that use **only** the native image/color splash (CLI only, no Flutter animation widget) are **not affected** — continue using `splash_master` alone with no code changes.
+#### For Native Image/Color Splash
+
+**No longer required:**
+- `SplashMaster.initialize()`
+- `SplashMaster.resume()`
+
+If you're using **only** the native image/color splash (CLI only, no Flutter animation widget), remove these calls, replace outdated parameters from the `pubspec.yaml` with new ones, and run `dart run splash_master create`. The native splash transitions automatically to your Flutter app.
+
+#### For Animation Widgets
+
+If using `SplashMasterRive`, `SplashMasterVideo`, or `SplashMasterLottie`, call the respective widget's `.initialize()` and `.resume()` methods in your main function.
 
 > `RiveFileSource` is available in `splash_master_rive`. Import `package:splash_master_rive/splash_master_rive.dart` to access it.
 
@@ -438,6 +448,8 @@ Apps that use **only** the native image/color splash (CLI only, no Flutter anima
 | `android_dark_gravity` fallback | Could independently default to `fill` | Falls back to `android_gravity` when omitted |
 | Validation strictness | Legacy/unknown keys could still exist in configs | Unsupported keys are rejected with a validation error |
 | iOS content mode aliases | `aspectFit` and `aspectFill` were accepted aliases | Use `scaleAspectFit` and `scaleAspectFill` |
+| `SplashMaster` factory class | Unified entry point for all splash animations | Removed — use dedicated sub-package widgets instead |
+| **Initialization / Lifecycle methods** | **`SplashMaster.initialize()` and `SplashMaster.resume()` required for all splash types** | **`SplashMaster.initialize()` and `SplashMaster.resume()` are no longer supported.** Use the respective animation widget's `.initialize()` and `.resume()` methods instead (e.g., `SplashMasterRive.initialize()`). Not needed for native image/color splash. |
 
 ## 1) Dark Mode Key Renames
 
@@ -544,7 +556,55 @@ when `background_image_dark` is used on Android.
 1.0.0 validates config keys strictly. Remove legacy keys and keep only supported
 keys, including supported nested keys under `android_12_and_above`.
 
-#### For a complete list of changes and new features in each version, please refer to [CHANGELOG.md](https://github.com/SimformSolutionsPvtLtd/splash_master/blob/master/CHANGELOG.md) on Github.
+## 7) Removed SplashMaster Lifecycle Methods
+
+`SplashMaster.initialize()` and `SplashMaster.resume()` are **no longer supported** in 1.0.0. These static methods on the `SplashMaster` factory class have been removed entirely.
+
+### For Native Image/Color Splash
+
+**No action required.** If you're using only the native image/color splash (CLI only, no Flutter animation widget), you never needed these methods. Simply configure `pubspec.yaml` and run `dart run splash_master create`.
+
+### For Animation Widgets
+
+If you were calling `SplashMaster.initialize()` or `SplashMaster.resume()`, replace them with the respective animation widget's methods:
+
+#### Before (0.0.3)
+
+```dart
+import 'package:splash_master/splash_master.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  SplashMaster.initialize();  // ❌ No longer supported
+  runApp(
+    MaterialApp(
+      home: SplashMaster.rive(
+        source: AssetSource('assets/animation.riv'),
+        nextScreen: const MyApp(),
+      ),
+    ),
+  );
+}
+```
+
+#### After (1.0.0) — Rive Example
+
+```dart
+import 'package:splash_master_rive/splash_master_rive.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  SplashMasterRive.initialize();  // ✅ Use widget-specific method
+  runApp(
+    MaterialApp(
+      home: SplashMasterRive(
+        source: AssetSource('assets/animation.riv'),
+        nextScreen: const MyApp(),
+      ),
+    ),
+  );
+}
+```
 
 # Contributors
 

--- a/splash_master/CHANGELOG.md
+++ b/splash_master/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.0.0]
 
 - Improvement - Added dedicated example(s) for each package to make integration and issue reproduction easier.
+- [Breaking] - Removed the legacy `SplashMaster.initialize()` and `SplashMaster.resume()` APIs from the shared package; lifecycle methods now live on the renderer-specific widgets/packages (for example, `SplashMasterRive.initialize()` / `resume()`).
 - [Breaking] - Fixed [#83](https://github.com/SimformSolutionsPvtLtd/splash_master/issues/83) & [#75](https://github.com/SimformSolutionsPvtLtd/splash_master/issues/75) Split Flutter animation widgets into dedicated packages: `splash_master_rive`, `splash_master_lottie`, and `splash_master_video`, while keeping `splash_master` focused on CLI/native generation and shared types.
 - [Breaking] - Renamed `image_dark_android` to `image_dark` & `color_dark_android` to `color_dark` for consistency across platforms.
 - [Breaking] - Android 12+ configuration is treated as an explicit nested block under `android_12_and_above` and validated independently.

--- a/splash_master/doc/documentation.md
+++ b/splash_master/doc/documentation.md
@@ -211,17 +211,26 @@ This version standardizes dark-mode keys, enforces strict config validation, int
 
 ### Flutter Widget API Changes
 
-`SplashMaster.rive(...)`, `SplashMaster.video(...)`, and `SplashMaster.lottie(...)` have been removed from the `splash_master` package. Add the relevant sub-package and rename the widget:
+The `SplashMaster` factory class has been removed. Animation widgets have been moved to dedicated sub-packages:
 
-| Before (0.0.3)              | After (1.0.0)            | New package              |
-|-----------------------------|--------------------------|--------------------------|
-| `SplashMaster.rive(...)`    | `SplashMasterRive(...)`        | `splash_master_rive`     |
-| `SplashMaster.video(...)`   | `SplashMasterVideo(...)`       | `splash_master_video`    |
-| `SplashMaster.lottie(...)`  | `SplashMasterLottie(...)`      | `splash_master_lottie`   |
-| `SplashMaster.initialize()` | `<Widget>.initialize()`  | same sub-package widget  |
-| `SplashMaster.resume()`     | `<Widget>.resume()`      | same sub-package widget  |
+| Before (0.0.3)              | After (1.0.0)            | Notes                                |
+|-----------------------------|--------------------------|--------------------------------------|
+| `SplashMaster.rive(...)`    | `SplashMasterRive(...)`  | Requires `splash_master_rive` package |
+| `SplashMaster.video(...)`   | `SplashMasterVideo(...)` | Requires `splash_master_video` package |
+| `SplashMaster.lottie(...)`  | `SplashMasterLottie(...)` | Requires `splash_master_lottie` package |
+| `SplashMaster.initialize()` | `<Widget>.initialize()`  | **Only needed for animation widgets** |
+| `SplashMaster.resume()`     | `<Widget>.resume()`      | **Only needed for animation widgets** |
 
-Apps that use **only** the native image/color splash (CLI only, no Flutter animation widget) are **not affected** — continue using `splash_master` alone with no code changes.
+#### For Native Image/Color Splash
+
+**No longer required:**
+- `SplashMaster.initialize()`
+- `SplashMaster.resume()`
+
+If you're using **only** the native image/color splash (CLI only, no Flutter animation widget), remove these calls, replace outdated parameters from the `pubspec.yaml` with new ones, and run `dart run splash_master create`. The native splash transitions automatically to your Flutter app.
+#### For Animation Widgets
+
+If using `SplashMasterRive`, `SplashMasterVideo`, or `SplashMasterLottie`, call the respective widget's `.initialize()` and `.resume()` methods in your main function.
 
 > `RiveFileSource` is available in `splash_master_rive`. Import `package:splash_master_rive/splash_master_rive.dart` to access it.
 
@@ -234,6 +243,8 @@ Apps that use **only** the native image/color splash (CLI only, no Flutter anima
 | `android_dark_gravity` fallback | Could independently default to `fill` | Falls back to `android_gravity` when omitted |
 | Validation strictness | Legacy/unknown keys could still exist in configs | Unsupported keys are rejected with a validation error |
 | iOS content mode aliases | `aspectFit` and `aspectFill` were accepted aliases | Use `scaleAspectFit` and `scaleAspectFill` |
+| `SplashMaster` factory class | Unified entry point for all splash animations | Removed — use dedicated sub-package widgets instead |
+| **Initialization / Lifecycle methods** | **`SplashMaster.initialize()` and `SplashMaster.resume()` required for all splash types** | **`SplashMaster.initialize()` and `SplashMaster.resume()` are no longer supported.** Use the respective animation widget's `.initialize()` and `.resume()` methods instead (e.g., `SplashMasterRive.initialize()`). Not needed for native image/color splash. |
 
 ## 1) Dark Mode Key Renames
 
@@ -339,6 +350,57 @@ when `background_image_dark` is used on Android.
 
 1.0.0 validates config keys strictly. Remove legacy keys and keep only supported
 keys, including supported nested keys under `android_12_and_above`.
+
+
+## 7) Removed SplashMaster Lifecycle Methods
+
+`SplashMaster.initialize()` and `SplashMaster.resume()` are **no longer supported** in 1.0.0. These static methods on the `SplashMaster` factory class have been removed entirely.
+
+### For Native Image/Color Splash
+
+**No action required.** If you're using only the native image/color splash (CLI only, no Flutter animation widget), you never needed these methods. Simply configure `pubspec.yaml` and run `dart run splash_master create`.
+
+### For Animation Widgets
+
+If you were calling `SplashMaster.initialize()` or `SplashMaster.resume()`, replace them with the respective animation widget's methods:
+
+#### Before (0.0.3)
+
+```dart
+import 'package:splash_master/splash_master.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  SplashMaster.initialize();  // ❌ No longer supported
+  runApp(
+    MaterialApp(
+      home: SplashMaster.rive(
+        source: AssetSource('assets/animation.riv'),
+        nextScreen: const MyApp(),
+      ),
+    ),
+  );
+}
+```
+
+#### After (1.0.0) — Rive Example
+
+```dart
+import 'package:splash_master_rive/splash_master_rive.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  SplashMasterRive.initialize();  // ✅ Use widget-specific method
+  runApp(
+    MaterialApp(
+      home: SplashMasterRive(
+        source: AssetSource('assets/animation.riv'),
+        nextScreen: const MyApp(),
+      ),
+    ),
+  );
+}
+```
 
 #### For a complete list of changes and new features in each version, please refer to [CHANGELOG.md](https://github.com/SimformSolutionsPvtLtd/splash_master/blob/master/CHANGELOG.md) on Github.
 


### PR DESCRIPTION
<!-- PR Title suggestion: docs: document removal of SplashMaster.initialize()/resume() in migration guide -->

# Description
This PR updates the documentation to clearly document the removal of the `SplashMaster.initialize()` and `SplashMaster.resume()` lifecycle methods in the migration / breaking changes sections.

Specifically:
- Updates `doc/documentation.md` to reflect that `SplashMaster.initialize()` and `SplashMaster.resume()` are no longer supported in v1.0.0.
- Updates the "Breaking Changes Summary" table row for Initialization / Lifecycle methods to state removal.
- Adds a new section `## 7) Removed SplashMaster Lifecycle Methods` to the migration guide with:
  - A clear statement that `SplashMaster.initialize()` and `SplashMaster.resume()` have been removed.
  - Guidance for native image/color splash (no action required).
  - Migration examples showing before (0.0.3) and after (1.0.0) usage, with concrete suggestions to use the widget-specific methods (`SplashMasterRive.initialize()`, `SplashMasterVideo.initialize()`, `SplashMasterLottie.initialize()`).
- No code changes were made — documentation-only.

Files changed:
- `doc/documentation.md`
- `splash_master/doc/documentation.md`
- `CHANGELOG.md`

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`docs:` suggested).
- [x] I have followed the [Contributor Guide] when preparing my PR (docs-only change; follows repository docs conventions).
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `doc/` and/or package README(s), and added dartdoc comments with `///` where applicable.
- [ ] I have updated/added relevant examples in `example/` and/or `splash_master_{rive,video,lottie}/example/`.
- [x] I have updated impacted package metadata/docs (for example: `README.md`, `CHANGELOG.md`, and package-level docs where applicable). (Documentation file updated — `doc/documentation.md`.)

### Impacted package(s)

- [x] splash_master (core) — documentation updated
- [ ] splash_master_rive
- [ ] splash_master_video
- [ ] splash_master_lottie

## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues
- Closes #119 